### PR TITLE
Fix broken docs links

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
             </a>
             <div class="nav-links">
                 <a href="https://github.com/near/near-cli-rs" target="_blank" rel="noopener">GitHub</a>
-                <a href="https://docs.near.org/tools/near-cli" target="_blank" rel="noopener">Docs</a>
+                <a href="https://docs.near.org/tools/cli#near-cli" target="_blank" rel="noopener">Docs</a>
                 <a href="https://near.org" target="_blank" rel="noopener">NEAR Protocol</a>
             </div>
         </div>
@@ -92,7 +92,7 @@
             </div>
 
             <div class="hero-cta">
-                <a href="https://docs.near.org/tools/near-cli" class="btn btn-primary">Read the docs</a>
+                <a href="https://docs.near.org/tools/cli#near-cli" class="btn btn-primary">Read the docs</a>
                 <a href="https://github.com/near/near-cli-rs" class="btn btn-secondary">View on GitHub</a>
             </div>
         </div>
@@ -347,7 +347,7 @@
             </div>
             <div class="footer-links">
                 <a href="https://github.com/near/near-cli-rs" target="_blank" rel="noopener">GitHub</a>
-                <a href="https://docs.near.org/tools/near-cli" target="_blank" rel="noopener">Documentation</a>
+                <a href="https://docs.near.org/tools/cli#near-cli" target="_blank" rel="noopener">Documentation</a>
                 <a href="https://near.org" target="_blank" rel="noopener">NEAR Protocol</a>
                 <a href="https://discord.gg/near" target="_blank" rel="noopener">Discord</a>
             </div>


### PR DESCRIPTION
## Summary

The documentation links on the landing page pointed to `https://docs.near.org/tools/near-cli`, which 404s. Updated all three occurrences in `index.html` to the correct URL: `https://docs.near.org/tools/cli#near-cli`.

Fixes near/near-cli-rs#601